### PR TITLE
Rails 3.1: Deprecation fix for #primary_key_name

### DIFF
--- a/lib/multitenant.rb
+++ b/lib/multitenant.rb
@@ -25,7 +25,7 @@ module Multitenant
         m.send "#{association}=".to_sym, Multitenant.current_tenant
       }, :on => :create
       default_scope lambda {
-        where({reflection.primary_key_name => Multitenant.current_tenant.id}) if Multitenant.current_tenant
+        where({reflection.foreign_key => Multitenant.current_tenant.id}) if Multitenant.current_tenant
       }
     end
   end


### PR DESCRIPTION
Small fix to remove the following deprecation warning with Rails 3.1

```
DEPRECATION WARNING: primary_key_name is deprecated and will be removed
from Rails 3.2 (use foreign_key instead)
```
