### PR TITLE
Restore previous tenant and tenant callback

### DIFF
--- a/lib/multitenant.rb
+++ b/lib/multitenant.rb
@@ -3,18 +3,20 @@ require 'active_record'
 # Multitenant: making cross tenant data leaks a thing of the past...since 2011
 module Multitenant
   class << self
-    attr_accessor :current_tenant
+    attr_reader :current_tenant
+
+    def current_tenant=(tenant)
+      @current_tenant = tenant
+      @current_tenant.became_current_tenant if @current_tenant.respond_to?(:became_current_tenant)
+      @current_tenant
+    end
 
     # execute a block scoped to the current tenant
     # unsets the current tenant after execution
     # @param [Object] tenant the new current tenant
-    # @param [Hash] options
-    # @option options [Symbol] :became_current_tenant_method (:became_current_tenant) name of the method to call on tenant after it became the current one (and before the block is run)
-    def with_tenant(tenant, options={}, &block)
-      options[:became_current_tenant_method] ||= :became_current_tenant
+    def with_tenant(tenant, &block)
       previous_tenant = Multitenant.current_tenant
       Multitenant.current_tenant = tenant
-      tenant.send(options[:became_current_tenant_method]) if tenant.respond_to?(options[:became_current_tenant_method])
       yield
     ensure
       Multitenant.current_tenant = previous_tenant

--- a/spec/multitenant_spec.rb
+++ b/spec/multitenant_spec.rb
@@ -23,6 +23,11 @@ end
 
 class Company < ActiveRecord::Base
   has_many :users
+  attr_accessor :now_is_current_tenant
+
+  def became_current_tenant
+    self.now_is_current_tenant = true
+  end
 end
 class User < ActiveRecord::Base
   belongs_to :company
@@ -41,8 +46,13 @@ describe Multitenant do
   after { Multitenant.current_tenant = nil }
 
   describe 'Multitenant.current_tenant' do
-    before { Multitenant.current_tenant = :foo }
-    it { Multitenant.current_tenant == :foo }
+    before do
+      @company = Company.create!(:name => 'foo')
+      @company.now_is_current_tenant.should == nil
+      Multitenant.current_tenant = @company
+    end
+    it { Multitenant.current_tenant.should == @company }
+    it { @company.now_is_current_tenant.should == true }
   end
 
   describe 'Multitenant.with_tenant block' do
@@ -94,12 +104,13 @@ describe Multitenant do
     end
     it 'yields the block' do
       @executed.should == true
-    end    
+    end
   end
 
   describe 'User.all when current_tenant is set' do
     before do
       @company = Company.create!(:name => 'foo')
+      @company.now_is_current_tenant.should == nil
       @company2 = Company.create!(:name => 'bar')
 
       @user = @company.users.create! :name => 'bob'
@@ -110,6 +121,7 @@ describe Multitenant do
     end
     it { @users.length.should == 1 }
     it { @users.should == [@user] }
+    it { @company.now_is_current_tenant.should == true }
   end
 
   describe 'Item.all when current_tenant is set' do


### PR DESCRIPTION
In this pull request I'm including a feature which I sent in a previous one that I closed:
- when leaving the scope of a tenant, restore the previous tenant

as well as a new feature: when entering the scope of a tenant, call a method in the object.

Everything includes tests. The previous feature has been in production for months and the second one will be in production soon.
