### PR TITLE
Checks for matching association class before multitenanting

### DIFF
--- a/lib/multitenant.rb
+++ b/lib/multitenant.rb
@@ -19,12 +19,14 @@ module Multitenant
     # configure the current model to automatically query and populate objects based on the current tenant
     # see Multitenant#current_tenant
     def belongs_to_multitenant(association = :tenant)
-      reflection = reflect_on_association association
+      reflection      = reflect_on_association association
+      multitenantable = -> { Multitenant.current_tenant && Multitenant.current_tenant.class == reflection.klass }
+
       before_validation Proc.new {|m|
-        m.send("#{association}=".to_sym, Multitenant.current_tenant) if Multitenant.current_tenant
+        m.send("#{association}=".to_sym, Multitenant.current_tenant) if multitenantable.call
       }, :on => :create
       default_scope lambda {
-        where({reflection.foreign_key => Multitenant.current_tenant.id}) if Multitenant.current_tenant
+        where({reflection.foreign_key => Multitenant.current_tenant.id}) if multitenantable.call
       }
     end
   end

--- a/multitenant.gemspec
+++ b/multitenant.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sqlite3', ["~> 1.3.3"])
   s.add_development_dependency('rspec', ['~> 2.6.0'])
   s.add_development_dependency('rspec-core', ['~> 2.6.4'])
+  s.add_development_dependency('pry')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/multitenant.gemspec
+++ b/multitenant.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "multitenant"
 
-  s.add_dependency(%q<activerecord>, ['>= 3.1'])
+  s.add_dependency(%q<activerecord>, ['>= 3.1', '< 5.0.0'])
 
   s.add_development_dependency('rake')
   s.add_development_dependency('sqlite3', ["~> 1.3.3"])

--- a/multitenant.gemspec
+++ b/multitenant.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<activerecord>, ['>= 3.1', '< 5.0.0'])
 
-  s.add_development_dependency('rake')
+  s.add_development_dependency('rake', ["< 11"])
   s.add_development_dependency('sqlite3', ["~> 1.3.3"])
   s.add_development_dependency('rspec', ['~> 2.6.0'])
   s.add_development_dependency('rspec-core', ['~> 2.6.4'])

--- a/spec/multitenant_spec.rb
+++ b/spec/multitenant_spec.rb
@@ -109,6 +109,23 @@ describe Multitenant do
     it { @items.should == [@item] }
   end
 
+  describe 'Item.all when current_tenant is set to the incorrect tenant' do
+    before do
+      Item.delete_all
+      @company = Company.create! :name => 'foo'
+      @tenant  = Tenant.create!(:name => 'foo')
+      @tenant2 = Tenant.create!(:name => 'bar')
+      @item    = @tenant.items.create! :name => 'baz'
+      @item2   = @tenant2.items.create! :name => 'booz'
+
+      Multitenant.with_tenant @company do
+        @items = Item.all.to_ary
+      end
+    end
+    it { @items.length.should == 2 }
+    it { @items.should == [@item, @item2] }
+  end
+
 
   describe 'creating new object when current_tenant is set' do
     before do

--- a/spec/multitenant_spec.rb
+++ b/spec/multitenant_spec.rb
@@ -87,7 +87,7 @@ describe Multitenant do
       @user = @company.users.create! :name => 'bob'
       @user2 = @company2.users.create! :name => 'tim'
       Multitenant.with_tenant @company do
-        @users = User.all
+        @users = User.all.to_ary
       end
     end
     it { @users.length.should == 1 }
@@ -102,7 +102,7 @@ describe Multitenant do
       @item = @tenant.items.create! :name => 'baz'
       @item2 = @tenant2.items.create! :name => 'booz'
       Multitenant.with_tenant @tenant do
-        @items = Item.all
+        @items = Item.all.to_ary
       end
     end
     it { @items.length.should == 1 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rspec'
 require 'multitenant'
 require 'active_record'
 require 'logger'
+require 'pry'
 
 config = YAML::load(IO.read(File.join(File.dirname(__FILE__), 'database.yml')))
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))


### PR DESCRIPTION
This PR will make sure that the gem will only tenant with the correct classes. I.e.

Given that:

- Tenant has many Items,
- Company has many users

It was possible to incorrectly se tup multitenant with

```ruby
Multitenant.with_tenant @company do
  @items = Item.all
end
```

The fix in this PR will do a check on the association to make sure that association classes match before applying multi-tenanting.

BONUS: I've also updated the specs to work with activerecord ~> 4.0.0